### PR TITLE
Update CI workflow to restrict GitHub Pages deployment to the main br…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,7 @@ jobs:
   deploy-coverage-pages:
     runs-on: ubuntu-latest
     needs: build-test-coverage
-    if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
…anch only

- Modified the deployment condition in the CI workflow to trigger only on the main branch, enhancing control over deployment processes.